### PR TITLE
Add immediate parameter port to Counter component

### DIFF
--- a/components/Counter.coffee
+++ b/components/Counter.coffee
@@ -8,14 +8,20 @@ class Counter extends noflo.Component
 
   constructor: ->
     @count = null
-    
+
     # Set up ports
     @inPorts =
       in: new noflo.Port
+      immediate: new noflo.Port 'boolean'
     @outPorts =
       count: new noflo.Port 'number'
       out: new noflo.Port
-     
+
+    #
+    @immediate = false
+    @inPorts.immediate.on 'data', (value) =>
+      @immediate = value
+
     # When receiving data from IN port
     @inPorts.in.on 'data', (data) =>
       # Prepare and increment counter
@@ -23,12 +29,18 @@ class Counter extends noflo.Component
       @count++
       # Forward the data packet to OUT
       @outPorts.out.send data if @outPorts.out.isAttached()
-      
+      @sendCount() if @immediate
+
     # When IN port disconnects we send the COUNT
     @inPorts.in.on 'disconnect', =>
-      @outPorts.count.send @count
-      @outPorts.count.disconnect()
+      @sendCount() unless @immediate
       @outPorts.out.disconnect() if @outPorts.out.isAttached()
       @count = null
+
+  sendCount: () ->
+    return unless @outPorts.count.isAttached()
+    @outPorts.count.send @count
+    @outPorts.count.disconnect()
+
 
 exports.getComponent = -> new Counter

--- a/test/Counter.coffee
+++ b/test/Counter.coffee
@@ -1,0 +1,33 @@
+test = require "noflo-test"
+
+test.component("packets/Counter").
+  discuss("given some IPs").
+    send.connect("in").
+      send.data("in", "a").
+      send.data("in", "b").
+      send.data("in", "c").
+      send.data("in", "d").
+    send.disconnect("in").
+  discuss("returns the number of IPs").
+    receive.data("out", "a").
+    receive.data("out", "b").
+    receive.data("out", "c").
+    receive.data("out", "d").
+    receive.data("count", 4).
+
+  next().
+  discuss("given some IPs with immediate parameter").
+    send.connect("immediate").
+      send.data("immediate", true).
+      send.disconnect("immediate").
+    send.connect("in").
+      send.data("in", "a").
+      send.data("in", "b").
+  discuss("returns the number of IPs").
+    receive.data("out", "a").
+    receive.data("count", 1).
+    receive.data("out", "b").
+    receive.data("count", 2).
+    send.disconnect("in").
+
+export module


### PR DESCRIPTION
In some cases, you might want to get the number of IIPs gone throught the Counter component before a disconnect happens.
This patch adds the immediate boolean port to parametrize the component.
