### PR TITLE
not sure why but this seems necessary

### DIFF
--- a/components/CountPackets.coffee
+++ b/components/CountPackets.coffee
@@ -28,10 +28,11 @@ class CountPackets extends noflo.Component
 
     @inPorts.in.on "endgroup", (group) =>
       count = _.last(@counts)
+      @counts.pop()
       @outPorts.count.send(count)
       @outPorts.count.endGroup()
-      @counts.pop()
-      @outPorts.out.endGroup(group)
+      @outPorts.count.disconnect()
+      @outPorts.out.endGroup()
 
     @inPorts.in.on "disconnect", =>
       count = _.last(@counts)


### PR DESCRIPTION
The only new line is the `@outPorts.count.disconnect`. The other changes are just re-organizing that code block a little.

So, on this PR... I tested in some graphs where I would run the network with and without an instance of `CountPackets`. Without `CountPackets`, the network ends as expected, but with `CountPackets` the network hangs (until I added this line).

I'm not sure why that behavior was happening though as it looks to me like it _should_ be disconnecting when in `in` port disconnects. I proved to myself that all down and upstream components were disconnecting properly by injecting `CountPackets` in various places... every time it caused the network to hang (whereas the same network without it does not hang).

So I'm making the PR because it fixes the behavior I was noticing, but I'm apprehensive as I don't fully understand why the disconnect lower down wasn't covering things... Hoping someone knows what's going on here.