### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,23 +22,23 @@
     }
   ],
   "dependencies": {
-    "noflo": "~0.5.0",
-    "underscore": "1.4.x"
+    "noflo": "0.5.13",
+    "underscore": "1.4.4"
   },
   "devDependencies": {
-    "grunt-exec": "~0.4.2",
-    "noflo-test": "~0.0.4",
-    "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.6.6",
-    "grunt-coffeelint": "~0.0.6",
-    "grunt-cafe-mocha": "~0.1.2",
-    "chai": "~1.5.0",
-    "mocha": "~1.9.0",
-    "grunt-mocha-phantomjs": "~0.2.2",
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-watch": "~0.3.1",
-    "grunt-noflo-manifest": "^0.1.4",
-    "grunt-noflo-browser": "^0.1.1"
+    "grunt-exec": "0.4.6",
+    "noflo-test": "0.0.7",
+    "grunt": "0.4.5",
+    "grunt-contrib-coffee": "0.6.7",
+    "grunt-coffeelint": "0.0.13",
+    "grunt-cafe-mocha": "0.1.13",
+    "chai": "1.5.0",
+    "mocha": "1.9.0",
+    "grunt-mocha-phantomjs": "0.2.8",
+    "grunt-contrib-uglify": "0.2.7",
+    "grunt-contrib-watch": "0.3.1",
+    "grunt-noflo-manifest": "0.1.11",
+    "grunt-noflo-browser": "0.1.11"
   },
   "noflo": {
     "icon": "dropbox",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>